### PR TITLE
Updated with most recent metadata/build date

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ download and install Metasploit itself.
 
 To build the gem:
 
-1. Update the version number in `lib/meterpreter_binaries/version.rb`
+1. Update the version number in `lib/meterpreter_bins/version.rb`
 1. Run `rake win_prep` to build on Windows or `rake posix_prep` to build
    on Linux.
 1. Binaries will be built in the `meterpreter` folder.

--- a/meterpreter_bins.gemspec
+++ b/meterpreter_bins.gemspec
@@ -4,15 +4,16 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'meterpreter_bins/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "meterpreter_bins"
+  spec.name          = 'meterpreter_bins'
   spec.version       = MeterpreterBinaries::VERSION
-  spec.authors       = ["OJ Reeves", "Tod Beardsley", "Chris Doughty"]
-  spec.email         = ["oj@buffered.io", "tod_beardsley@rapid7.com", "chris_doughty@rapid7.com"]
+  spec.date          = '2014-08-20'
+  spec.authors       = ['OJ Reeves', 'Tod Beardsley', 'Chris Doughty']
+  spec.email         = ['oj@buffered.io', 'tod_beardsley@rapid7.com', 'chris_doughty@rapid7.com']
   spec.description   = %q{Compiled binaries for Metasploit's Meterpreter}
   spec.summary       = %q{This gem contains the compiled binaries required to make
                         Meterpreter function for Windows 32-bit and 64-bit targets.
                         Other binaries will be added in future versions.}
-  spec.homepage      = "http://www.metasploit.com"
+  spec.homepage      = 'http://www.metasploit.com'
   spec.license       = '3-clause (or "modified") BSD'
 
   spec.files         = `git ls-files`.split("\n")
@@ -36,10 +37,10 @@ Gem::Specification.new do |spec|
   # up. In this way, the gem version can be linked to a commit hash and
   # users can get a sense of where in the history they are.
   #spec.metadata['source']              = 'https://github.com/rapid7/meterpreter'
-  #spec.metadata['source_commit']       = 'e77c87cdb79a2732108be937e056622b45cb093c'
+  #spec.metadata['source_commit']       = '51b1a6d1dce9f617ab5fe0f27796e2217d9a9ca6'
   #spec.metadata['source_commit_url']   = "#{spec.metadata['source']}/commit/#{spec.metadata['source_commit']}"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "gem-release"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'gem-release'
 end


### PR DESCRIPTION
Also updated the readme which contained an invalid path.

The version number of the gem in the source was not modified because this was out of sync with the pushed meterpreter gem file anyway. The version will remain 0.0.7 in source and the pushed meterpreter bins gem
will match this version.
