### PR TITLE
Update to 0.0.8

### DIFF
--- a/lib/meterpreter_bins/version.rb
+++ b/lib/meterpreter_bins/version.rb
@@ -1,6 +1,6 @@
 # -*- coding:binary -*-
 module MeterpreterBinaries
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 
   def self.version
     VERSION


### PR DESCRIPTION
This should wait until rapid7/meterpreter#100 is complete.

For instructions on what to do with this, see rapid7#4
