### PR TITLE
Removing spec.date to limit commit churn when new gems are released

### DIFF
--- a/meterpreter_bins.gemspec
+++ b/meterpreter_bins.gemspec
@@ -6,7 +6,6 @@ require 'meterpreter_bins/version'
 Gem::Specification.new do |spec|
   spec.name          = 'meterpreter_bins'
   spec.version       = MeterpreterBinaries::VERSION
-  spec.date          = '2014-10-15'
   spec.authors       = ['OJ Reeves', 'Tod Beardsley', 'Chris Doughty']
   spec.email         = ['oj@buffered.io', 'tod_beardsley@rapid7.com', 'chris_doughty@rapid7.com']
   spec.description   = %q{Compiled binaries for Metasploit's Meterpreter}


### PR DESCRIPTION
The build process will use the current date when we build/release this gem, so the date only adds an extra commit that must be made.  Talked to @todb-r7 and agreed removing is fine.  Please once over the code change and comment if there are any complaints.  Thanks.
